### PR TITLE
fix: lint errors in generate_examples.py and CLI test stderr handling

### DIFF
--- a/scripts/generate_examples.py
+++ b/scripts/generate_examples.py
@@ -242,7 +242,7 @@ def render_example_file(
     lines.append("")
     lines.append("")
     lines.append("async def main():")
-    lines.append(f"    async with AsyncTikHub(api_key=API_KEY) as client:")
+    lines.append("    async with AsyncTikHub(api_key=API_KEY) as client:")
 
     for entry in ops:
         kwargs, body_kind = collect_call_kwargs(entry["op"], spec)
@@ -257,7 +257,7 @@ def render_example_file(
             lines.append(f"        # {summary.rstrip()}")
 
         if body_kind == "multipart":
-            lines.append(f"        # Skipped: multipart upload (needs a real file)")
+            lines.append("        # Skipped: multipart upload (needs a real file)")
         else:
             if kwargs:
                 args = ", ".join(f"{k}={py_literal(v)}" for k, v in kwargs.items())

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -150,7 +150,7 @@ def test_health_no_api_key():
     result = runner.invoke(app, ["health"])
     assert result.exit_code == 2
     # Confirm it's the SDK config error, not a typer crash.
-    assert "API key" in result.stderr or "API key" in result.stdout
+    assert "API key" in result.output
 
 
 def test_health_upstream_error(monkeypatch: pytest.MonkeyPatch):
@@ -173,4 +173,4 @@ def test_health_upstream_error(monkeypatch: pytest.MonkeyPatch):
     )
     result = runner.invoke(app, ["health"])
     assert result.exit_code == 1
-    assert "500" in (result.stderr + result.stdout)
+    assert "500" in result.output


### PR DESCRIPTION
- Remove extraneous f-string prefixes (F541)
- Use result.output instead of result.stderr in CLI tests (typer CliRunner doesn't capture stderr separately by default)